### PR TITLE
Add support for date types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -799,6 +799,12 @@
                 </exclusions>
             </dependency>
 
+			<dependency>
+				<groupId>com.datastax.cassandra</groupId>
+				<artifactId>cassandra-driver-extras</artifactId>
+				<version>3.1.4</version>
+			</dependency>
+
             <dependency>
                 <groupId>com.teradata.tempto</groupId>
                 <artifactId>tempto-ldap</artifactId>

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraClientModule.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraClientModule.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.cassandra;
 
 import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.CodecRegistry;
 import com.datastax.driver.core.ProtocolVersion;
 import com.datastax.driver.core.QueryOptions;
 import com.datastax.driver.core.SocketOptions;
@@ -79,7 +80,11 @@ public class CassandraClientModule
         requireNonNull(config, "config is null");
         requireNonNull(extraColumnMetadataCodec, "extraColumnMetadataCodec is null");
 
+        CodecRegistry codecRegistry = new CodecRegistry();
+        codecRegistry.register(new LocalDateCustomCodec());
+
         Cluster.Builder clusterBuilder = Cluster.builder()
+                .withCodecRegistry(codecRegistry)
                 .withProtocolVersion(ProtocolVersion.V3);
 
         List<String> contactPoints = requireNonNull(config.getContactPoints(), "contactPoints is null");

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraRecordCursor.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraRecordCursor.java
@@ -107,6 +107,8 @@ public class CassandraRecordCursor
                 return currentRow.getLong(i);
             case TIMESTAMP:
                 return currentRow.getTimestamp(i).getTime();
+            case DATE:
+                return currentRow.getDate(i).getDaysSinceEpoch();
             case FLOAT:
                 return floatToRawIntBits(currentRow.getFloat(i));
             default:

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraType.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraType.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.cassandra;
 
 import com.datastax.driver.core.DataType;
+import com.datastax.driver.core.LocalDate;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.utils.Bytes;
 import com.facebook.presto.cassandra.util.CassandraCqlUtils;
@@ -339,7 +340,8 @@ public enum CassandraType
                 case TIMESTAMP:
                     return Long.toString(row.getTimestamp(i).getTime());
                 case DATE:
-                    return CassandraCqlUtils.quoteStringLiteral(row.getDate(i).toString());
+                    return CassandraCqlUtils.quoteStringLiteral(
+                            LocalDate.fromDaysSinceEpoch(row.getDate(i).getDaysSinceEpoch()).toString());
                 case INET:
                     return CassandraCqlUtils.quoteStringLiteral(toAddrString(row.getInet(i)));
                 case VARINT:
@@ -440,7 +442,7 @@ public enum CassandraType
             case TIMESTAMP:
                 return new Date((Long) nativeValue);
             case DATE:
-                return ((Long) nativeValue).intValue();
+                return LocalDate.fromDaysSinceEpoch(((Long) nativeValue).intValue());
             case UUID:
             case TIMEUUID:
                 return java.util.UUID.fromString(((Slice) nativeValue).toStringUtf8());

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraType.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraType.java
@@ -70,6 +70,7 @@ public enum CassandraType
     INT(IntegerType.INTEGER, Integer.class),
     TEXT(createUnboundedVarcharType(), String.class),
     TIMESTAMP(TimestampType.TIMESTAMP, Date.class),
+    DATE(DateType.DATE, Date.class),
     UUID(createVarcharType(Constants.UUID_STRING_MAX_LENGTH), java.util.UUID.class),
     TIMEUUID(createVarcharType(Constants.UUID_STRING_MAX_LENGTH), java.util.UUID.class),
     VARCHAR(createUnboundedVarcharType(), String.class),
@@ -131,6 +132,8 @@ public enum CassandraType
                 return COUNTER;
             case CUSTOM:
                 return CUSTOM;
+            case DATE:
+                return DATE;
             case DECIMAL:
                 return DECIMAL;
             case DOUBLE:
@@ -208,6 +211,8 @@ public enum CassandraType
                     return NullableValue.of(nativeType, utf8Slice(row.getUUID(i).toString()));
                 case TIMESTAMP:
                     return NullableValue.of(nativeType, row.getTimestamp(i).getTime());
+                case DATE:
+                    return NullableValue.of(nativeType, (long) row.getDate(i).getDaysSinceEpoch());
                 case INET:
                     return NullableValue.of(nativeType, utf8Slice(toAddrString(row.getInet(i))));
                 case VARINT:
@@ -333,6 +338,8 @@ public enum CassandraType
                     return row.getUUID(i).toString();
                 case TIMESTAMP:
                     return Long.toString(row.getTimestamp(i).getTime());
+                case DATE:
+                    return CassandraCqlUtils.quoteStringLiteral(row.getDate(i).toString());
                 case INET:
                     return CassandraCqlUtils.quoteStringLiteral(toAddrString(row.getInet(i)));
                 case VARINT:
@@ -356,6 +363,7 @@ public enum CassandraType
             case UUID:
             case TIMEUUID:
             case TIMESTAMP:
+            case DATE:
             case INET:
             case VARINT:
                 return CassandraCqlUtils.quoteStringLiteralForJson(object.toString());
@@ -431,6 +439,8 @@ public enum CassandraType
                 return new BigDecimal(nativeValue.toString());
             case TIMESTAMP:
                 return new Date((Long) nativeValue);
+            case DATE:
+                return ((Long) nativeValue).intValue();
             case UUID:
             case TIMEUUID:
                 return java.util.UUID.fromString(((Slice) nativeValue).toStringUtf8());
@@ -463,6 +473,7 @@ public enum CassandraType
             case FLOAT:
             case DECIMAL:
             case TIMESTAMP:
+            case DATE:
             case UUID:
             case TIMEUUID:
                 return value;
@@ -536,7 +547,7 @@ public enum CassandraType
             return TEXT;
         }
         else if (type.equals(DateType.DATE)) {
-            return TEXT;
+            return DATE;
         }
         else if (type.equals(VarbinaryType.VARBINARY)) {
             return BLOB;

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/LocalDateCustomCodec.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/LocalDateCustomCodec.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cassandra;
+
+import com.datastax.driver.core.DataType;
+import com.datastax.driver.core.LocalDate;
+import com.datastax.driver.core.ProtocolVersion;
+import com.datastax.driver.core.TypeCodec;
+import com.datastax.driver.core.exceptions.InvalidTypeException;
+
+import java.nio.ByteBuffer;
+
+public class LocalDateCustomCodec extends TypeCodec<LocalDate>
+{
+    public LocalDateCustomCodec()
+    {
+        super(DataType.custom("org.apache.cassandra.db.marshal.SimpleDateType"), LocalDate.class);
+    }
+
+    @Override
+    public ByteBuffer serialize(LocalDate value, ProtocolVersion protocolVersion) throws InvalidTypeException
+    {
+        return date().serialize(value, protocolVersion);
+    }
+
+    @Override
+    public LocalDate deserialize(ByteBuffer bytes, ProtocolVersion protocolVersion) throws InvalidTypeException
+    {
+        return date().deserialize(bytes, protocolVersion);
+    }
+
+    @Override
+    public LocalDate parse(String value) throws InvalidTypeException
+    {
+        return date().parse(value);
+    }
+
+    @Override
+    public String format(LocalDate value) throws InvalidTypeException
+    {
+        return date().format(value);
+    }
+}

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/util/CassandraCqlUtils.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/util/CassandraCqlUtils.java
@@ -39,7 +39,7 @@ public final class CassandraCqlUtils
     private static final String[] KEYWORDS = {"ADD", "ALL", "ALLOW", "ALTER", "AND", "APPLY",
             "ASC", "ASCII", "AUTHORIZE", "BATCH", "BEGIN", "BIGINT", "BLOB", "BOOLEAN", "BY",
             "CLUSTERING", "COLUMNFAMILY", "COMPACT", "COUNT", "COUNTER", "CREATE", "DECIMAL",
-            "DELETE", "DESC", "DOUBLE", "DROP", "FILTERING", "FLOAT", "FROM", "GRANT", "IN",
+            "DATE", "DELETE", "DESC", "DOUBLE", "DROP", "FILTERING", "FLOAT", "FROM", "GRANT", "IN",
             "INDEX", "INET", "INSERT", "INT", "INTO", "KEY", "KEYSPACE", "KEYSPACES", "LIMIT",
             "LIST", "MAP", "MODIFY", "NORECURSIVE", "NOSUPERUSER", "OF", "ON", "ORDER", "PASSWORD",
             "PERMISSION", "PERMISSIONS", "PRIMARY", "RENAME", "REVOKE", "SCHEMA", "SELECT", "SET", "SMALLINT",

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/CassandraTestingUtils.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/CassandraTestingUtils.java
@@ -123,6 +123,7 @@ public class CassandraTestingUtils
                 " typetinyint tinyint, " +
                 " typebytes blob, " +
                 " typetimestamp timestamp, " +
+                " typedate date, " +
                 " typeansi ascii, " +
                 " typeboolean boolean, " +
                 " typedecimal decimal, " +
@@ -152,6 +153,7 @@ public class CassandraTestingUtils
                 " typetinyint tinyint, " +
                 " typebytes blob, " +
                 " typetimestamp timestamp, " +
+                " typedate date, " +
                 " typeansi ascii, " +
                 " typeboolean boolean, " +
                 " typedecimal decimal, " +
@@ -174,6 +176,7 @@ public class CassandraTestingUtils
                 // TODO: NOT YET SUPPORTED AS A PARTITION KEY
                 // "   typebytes, " +
                 "   typetimestamp, " +
+                "   typedate, " +
                 "   typeansi, " +
                 "   typeboolean, " +
                 // TODO: PRECISION LOST. IMPLEMENT IT AS STRING
@@ -207,6 +210,7 @@ public class CassandraTestingUtils
                     .value("typetinyint", rowNumber.byteValue())
                     .value("typebytes", ByteBuffer.wrap(Ints.toByteArray(rowNumber)).asReadOnlyBuffer())
                     .value("typetimestamp", date)
+                    .value("typedate", date)
                     .value("typeansi", "ansi " + rowNumber)
                     .value("typeboolean", rowNumber % 2 == 0)
                     .value("typedecimal", new BigDecimal(Math.pow(2, rowNumber)))

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraType.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraType.java
@@ -34,6 +34,7 @@ public class TestCassandraType
         assertTrue(isValidJson(CassandraType.buildArrayValue(Lists.newArrayList(1.0, 2.0, 3.0), CassandraType.DOUBLE)));
         assertTrue(isValidJson(CassandraType.buildArrayValue(Lists.newArrayList((short) -32768, (short) 0, (short) 32767), CassandraType.SMALLINT)));
         assertTrue(isValidJson(CassandraType.buildArrayValue(Lists.newArrayList((byte) -128, (byte) 0, (byte) 127), CassandraType.TINYINT)));
+        assertTrue(isValidJson(CassandraType.buildArrayValue(Lists.newArrayList("25-05-2017", "26-06-2017", "27-07-2017"), CassandraType.DATE)));
     }
 
     private static void continueWhileNotNull(JsonParser parser, JsonToken token)


### PR DESCRIPTION
Adds support for date types, ensuring that the codec for conversion between byte buffers to LocalDate is registered with the cluster builder.